### PR TITLE
Move results table and enhance formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,55 +41,6 @@
     </p>
   </section>
 
-  <section id="benchmarks">
-    <h2>Benchmark Results</h2>
-    <div class="table-container">
-      <table class="benchmark">
-        <thead>
-          <tr><th rowspan="4">Type</th><th rowspan="4">Category</th><th colspan="2">Reasoning</th><th colspan="5">Big Models</th><th colspan="4">Small Models</th></tr>
-          <tr><th>32.8B</th><th>671B</th><th>671B</th><th>70B</th><th>27.2B</th><th>14B</th><th>N/A</th><th>8B</th><th>9.2B</th><th>3.8B</th><th>N/A</th></tr>
-          <tr><th>0.6</th><th>0.6</th><th>0.3</th><th>0.0</th><th>0.5</th><th>0.0</th><th>1.0</th><th>0.6</th><th>0.5</th><th>0.7</th><th>1.0</th></tr>
-          <tr><th><img src="logos/qwen-color.png" class="logo" alt=""/></th><th><img src="logos/deepseek-color.png" class="logo" alt=""/></th><th><img src="logos/deepseek-color.png" class="logo" alt=""/></th><th><img src="logos/meta-color.png" class="logo" alt=""/></th><th><img src="logos/gemma (1).png" class="logo" alt=""/></th><th><img src="logos/microsoft-color.png" class="logo" alt=""/></th><th><img src="logos/openai (1).png" class="logo" alt=""/></th><th><img src="logos/meta-color.png" class="logo" alt=""/></th><th><img src="logos/gemma (1).png" class="logo" alt=""/></th><th><img src="logos/microsoft-color.png" class="logo" alt=""/></th><th><img src="logos/openai (1).png" class="logo" alt=""/></th></tr>
-        </thead>
-        <tbody>
-          <tr><td>K</td><td>Distance</td><td>97.2</td><td>99.5</td><td>98.5</td><td>97.2</td><td>94.7</td><td>90.7</td><td>100</td><td>82.3</td><td>74.2</td><td>35.3</td><td>97.3</td></tr>
-          <tr><td>K</td><td>Area (counters)</td><td>85.3</td><td>99.5</td><td>95.7</td><td>81.7</td><td>46.5</td><td>79.2</td><td>98.5</td><td>30.8</td><td>37.5</td><td>9.8</td><td>80.3</td></tr>
-          <tr><td>K</td><td>Free Space</td><td>83.7</td><td>88.0</td><td>52.5</td><td>37.0</td><td>23.5</td><td>42.0</td><td>83.5</td><td>9.5</td><td>13.5</td><td>6.3</td><td>20.3</td></tr>
-          <tr><td>K</td><td>View Angle</td><td>74.0</td><td>58.2</td><td>69.2</td><td>75.2</td><td>12.7</td><td>52.8</td><td>86.3</td><td>11.5</td><td>9.2</td><td>8.2</td><td>42.2</td></tr>
-          <tr><td>K</td><td>Repositioning</td><td>91.5</td><td>96.3</td><td>69.8</td><td>48.7</td><td>14.8</td><td>22.7</td><td>85.8</td><td>3.7</td><td>6.2</td><td>11.5</td><td>40.7</td></tr>
-          <tr><td>K</td><td>Max Box</td><td>33.3</td><td>30.7</td><td>9.2</td><td>8.8</td><td>3.0</td><td>3.0</td><td>57.2</td><td>1.7</td><td>1.2</td><td>1.7</td><td>3.7</td></tr>
-          <tr><td>K</td><td>Fit/Placement</td><td>92.8</td><td>92.5</td><td>71.0</td><td>66.2</td><td>72.0</td><td>82.0</td><td>89.8</td><td>68.7</td><td>71.8</td><td>68.8</td><td>70.7</td></tr>
-          <tr><td>K</td><td>Path (Valid)</td><td>13.2†</td><td>6.3†</td><td>39.3</td><td>30.3</td><td>23.2</td><td>26.8</td><td>73.0</td><td>10.5</td><td>17.5</td><td>14.8</td><td>35.7</td></tr>
-          <tr><td>K</td><td>Path (Fréchet)</td><td>15.0</td><td>6.3</td><td>32.8</td><td>30.2</td><td>26.0</td><td>26.0</td><td>55.8</td><td>10.2</td><td>19.0</td><td>9.3</td><td>36.7</td></tr>
-          <tr><td>K</td><td>Missing Object</td><td>87.3</td><td>88.7</td><td>44.3</td><td>56.2</td><td>52.3</td><td>52.2</td><td>79.8</td><td>27.5</td><td>39.7</td><td>14.3</td><td>58.0</td></tr>
-          <tr><td>K</td><td>Obstruction</td><td>84.0</td><td>95.2</td><td>32.7</td><td>6.0</td><td>3.3</td><td>9.7</td><td>93.5</td><td>1.2</td><td>2.7</td><td>11.3</td><td>14.2</td></tr>
-          <tr><td>L</td><td>Distance</td><td>98.7</td><td>99.8</td><td>99.5</td><td>98.2</td><td>96.3</td><td>98.8</td><td>99.8</td><td>87.0</td><td>81.8</td><td>58.8</td><td>98.5</td></tr>
-          <tr><td>L</td><td>Area (sitting)</td><td>96.7</td><td>99.5</td><td>84.5</td><td>98.0</td><td>83.8</td><td>88.7</td><td>99.5</td><td>32.5</td><td>41.3</td><td>12.8</td><td>85.7</td></tr>
-          <tr><td>L</td><td>Free Space</td><td>0.3</td><td>4.3</td><td>1.0</td><td>0.3</td><td>3.7</td><td>0.3</td><td>5.0</td><td>0.7</td><td>3.2</td><td>1.5</td><td>1.7</td></tr>
-          <tr><td>L</td><td>View Angle</td><td>81.5</td><td>86.0</td><td>70.0</td><td>76.8</td><td>14.3</td><td>50.3</td><td>96.0</td><td>14.8</td><td>8.3</td><td>10.5</td><td>42.2</td></tr>
-          <tr><td>L</td><td>Repositioning</td><td>80.5</td><td>93.0</td><td>45.0</td><td>33.5</td><td>12.8</td><td>19.2</td><td>71.5</td><td>6.5</td><td>5.7</td><td>6.3</td><td>29.3</td></tr>
-          <tr><td>L</td><td>Max Box</td><td>1.5†</td><td>0.8†</td><td>1.0</td><td>3.0</td><td>2.0</td><td>2.8</td><td>6.5</td><td>0.8</td><td>1.5</td><td>1.0</td><td>2.3</td></tr>
-          <tr><td>L</td><td>Fit/Placement</td><td>90.7</td><td>91.2</td><td>71.5</td><td>80.0</td><td>83.7</td><td>87.7</td><td>91.8</td><td>75.0</td><td>75.5</td><td>72.8</td><td>72.7</td></tr>
-          <tr><td>L</td><td>Path (Valid)</td><td>10.0†</td><td>14.7†</td><td>33.0</td><td>26.7</td><td>30.5</td><td>26.7</td><td>53.2</td><td>7.3</td><td>21.7</td><td>16.7</td><td>33.5</td></tr>
-          <tr><td>L</td><td>Path (Fréchet)</td><td>13.2</td><td>14.2</td><td>23.7</td><td>17.8</td><td>19.2</td><td>14.7</td><td>48.0</td><td>2.5</td><td>14.2</td><td>6.8</td><td>25.2</td></tr>
-          <tr><td>L</td><td>Missing Object</td><td>73.0</td><td>76.2</td><td>51.0</td><td>49.3</td><td>29.5</td><td>36.0</td><td>65.5</td><td>9.7</td><td>28.3</td><td>11.7</td><td>32.3</td></tr>
-          <tr><td>L</td><td>Obstruction</td><td>80.7</td><td>96.5</td><td>24.3</td><td>7.3</td><td>3.8</td><td>9.3</td><td>84.7</td><td>2.5</td><td>5.2</td><td>4.7</td><td>11.7</td></tr>
-          <tr><td>B</td><td>Distance</td><td>98.7</td><td>99.8</td><td>99.5</td><td>98.2</td><td>96.3</td><td>98.8</td><td>99.8</td><td>87.0</td><td>81.8</td><td>58.8</td><td>98.5</td></tr>
-          <tr><td>B</td><td>Area (storage)</td><td>98.7</td><td>99.8</td><td>94.0</td><td>97.0</td><td>86.3</td><td>88.3</td><td>99.3</td><td>30.3</td><td>66.3</td><td>47.7</td><td>88.2</td></tr>
-          <tr><td>B</td><td>Free Space</td><td>1.7</td><td>5.8</td><td>1.2</td><td>0.3</td><td>2.5</td><td>1.2</td><td>2.8</td><td>1.8</td><td>1.0</td><td>1.0</td><td>1.2</td></tr>
-          <tr><td>B</td><td>View Angle</td><td>76.0</td><td>79.8</td><td>70.0</td><td>78.3</td><td>10.8</td><td>57.0</td><td>94.2</td><td>15.3</td><td>10.2</td><td>7.7</td><td>43.0</td></tr>
-          <tr><td>B</td><td>Repositioning</td><td>78.7</td><td>94.3</td><td>53.8</td><td>36.0</td><td>11.2</td><td>15.7</td><td>73.7</td><td>4.3</td><td>9.0</td><td>6.5</td><td>31.5</td></tr>
-          <tr><td>B</td><td>Max Box</td><td>0.7†</td><td>1.0†</td><td>2.0</td><td>1.8</td><td>2.0</td><td>2.5</td><td>7.2</td><td>1.0</td><td>0.7</td><td>1.0</td><td>2.0</td></tr>
-          <tr><td>B</td><td>Fit/Placement</td><td>86.3</td><td>86.3</td><td>65.8</td><td>66.7</td><td>66.5</td><td>73.0</td><td>82.0</td><td>66.0</td><td>63.8</td><td>64.7</td><td>66.2</td></tr>
-          <tr><td>B</td><td>Path (Valid)</td><td>15.5†</td><td>20.8†</td><td>49.7</td><td>40.7</td><td>38.5</td><td>35.8</td><td>67.8</td><td>11.3</td><td>34.5</td><td>20.5</td><td>48.8</td></tr>
-          <tr><td>B</td><td>Path (Fréchet)</td><td>15.3</td><td>21.5</td><td>30.3</td><td>30.3</td><td>27.0</td><td>19.0</td><td>49.5</td><td>3.7</td><td>19.7</td><td>8.5</td><td>36.3</td></tr>
-          <tr><td>B</td><td>Missing Object</td><td>64.3</td><td>65.2</td><td>39.8</td><td>40.3</td><td>33.0</td><td>25.2</td><td>61.0</td><td>14.8</td><td>19.7</td><td>8.3</td><td>34.5</td></tr>
-          <tr><td>B</td><td>Obstruction</td><td>87.2</td><td>95.7</td><td>32.0</td><td>4.3</td><td>1.3</td><td>5.8</td><td>89.5</td><td>2.2</td><td>5.3</td><td>9.3</td><td>12.2</td></tr>
-        </tbody>
-      </table>
-      <p class="table-note">†High truncation rate due to token limits.</p>
-    </div>
-  </section>
 
   <section id="gallery">
     <h2>Example Layouts</h2>
@@ -103,6 +54,55 @@
       <img src="images/img7.png" alt="Bedroom Example 1">
       <img src="images/img8.png" alt="Bedroom Example 2">
       <img src="images/img9.png" alt="Bedroom Example 3">
+    </div>
+  </section>
+  <section id="benchmarks">
+    <h2>Benchmark Results</h2>
+    <div class="table-container">
+      <table class="benchmark">
+        <thead>
+          <tr><th rowspan="4">Type</th><th rowspan="4">Category</th><th colspan="2">Reasoning</th><th colspan="5">Big Models</th><th colspan="4">Small Models</th></tr>
+          <tr><th>32.8B</th><th>671B</th><th>671B</th><th>70B</th><th>27.2B</th><th>14B</th><th>N/A</th><th>8B</th><th>9.2B</th><th>3.8B</th><th>N/A</th></tr>
+          <tr><th>0.6</th><th>0.6</th><th>0.3</th><th>0.0</th><th>0.5</th><th>0.0</th><th>1.0</th><th>0.6</th><th>0.5</th><th>0.7</th><th>1.0</th></tr>
+          <tr><th><img src="logos/qwen-color.png" class="logo" alt=""/></th><th><img src="logos/deepseek-color.png" class="logo" alt=""/></th><th><img src="logos/deepseek-color.png" class="logo" alt=""/></th><th><img src="logos/meta-color.png" class="logo" alt=""/></th><th><img src="logos/gemma (1).png" class="logo" alt=""/></th><th><img src="logos/microsoft-color.png" class="logo" alt=""/></th><th><img src="logos/openai (1).png" class="logo" alt=""/></th><th><img src="logos/meta-color.png" class="logo" alt=""/></th><th><img src="logos/gemma (1).png" class="logo" alt=""/></th><th><img src="logos/microsoft-color.png" class="logo" alt=""/></th><th><img src="logos/openai (1).png" class="logo" alt=""/></th></tr>
+        </thead>
+        <tbody>
+          <tr><td rowspan="11">K</td><td>Distance</td><td>97.2</td><td>99.5</td><td>98.5</td><td>97.2</td><td>94.7</td><td>90.7</td><td>100</td><td>82.3</td><td>74.2</td><td>35.3</td><td>97.3</td></tr>
+          <tr><td>Area (counters)</td><td>85.3</td><td>99.5</td><td>95.7</td><td>81.7</td><td>46.5</td><td>79.2</td><td>98.5</td><td>30.8</td><td>37.5</td><td>9.8</td><td>80.3</td></tr>
+          <tr><td>Free Space</td><td>83.7</td><td>88.0</td><td>52.5</td><td>37.0</td><td>23.5</td><td>42.0</td><td>83.5</td><td>9.5</td><td>13.5</td><td>6.3</td><td>20.3</td></tr>
+          <tr><td>View Angle</td><td>74.0</td><td>58.2</td><td>69.2</td><td>75.2</td><td>12.7</td><td>52.8</td><td>86.3</td><td>11.5</td><td>9.2</td><td>8.2</td><td>42.2</td></tr>
+          <tr><td>Repositioning</td><td>91.5</td><td>96.3</td><td>69.8</td><td>48.7</td><td>14.8</td><td>22.7</td><td>85.8</td><td>3.7</td><td>6.2</td><td>11.5</td><td>40.7</td></tr>
+          <tr><td>Max Box</td><td>33.3</td><td>30.7</td><td>9.2</td><td>8.8</td><td>3.0</td><td>3.0</td><td>57.2</td><td>1.7</td><td>1.2</td><td>1.7</td><td>3.7</td></tr>
+          <tr><td>Fit/Placement</td><td>92.8</td><td>92.5</td><td>71.0</td><td>66.2</td><td>72.0</td><td>82.0</td><td>89.8</td><td>68.7</td><td>71.8</td><td>68.8</td><td>70.7</td></tr>
+          <tr><td>Path (Valid)</td><td>13.2†</td><td>6.3†</td><td>39.3</td><td>30.3</td><td>23.2</td><td>26.8</td><td>73.0</td><td>10.5</td><td>17.5</td><td>14.8</td><td>35.7</td></tr>
+          <tr><td>Path (Fréchet)</td><td>15.0</td><td>6.3</td><td>32.8</td><td>30.2</td><td>26.0</td><td>26.0</td><td>55.8</td><td>10.2</td><td>19.0</td><td>9.3</td><td>36.7</td></tr>
+          <tr><td>Missing Object</td><td>87.3</td><td>88.7</td><td>44.3</td><td>56.2</td><td>52.3</td><td>52.2</td><td>79.8</td><td>27.5</td><td>39.7</td><td>14.3</td><td>58.0</td></tr>
+          <tr class="group-end"><td>Obstruction</td><td>84.0</td><td>95.2</td><td>32.7</td><td>6.0</td><td>3.3</td><td>9.7</td><td>93.5</td><td>1.2</td><td>2.7</td><td>11.3</td><td>14.2</td></tr>
+          <tr><td rowspan="11">L</td><td>Distance</td><td>98.7</td><td>99.8</td><td>99.5</td><td>98.2</td><td>96.3</td><td>98.8</td><td>99.8</td><td>87.0</td><td>81.8</td><td>58.8</td><td>98.5</td></tr>
+          <tr><td>Area (sitting)</td><td>96.7</td><td>99.5</td><td>84.5</td><td>98.0</td><td>83.8</td><td>88.7</td><td>99.5</td><td>32.5</td><td>41.3</td><td>12.8</td><td>85.7</td></tr>
+          <tr><td>Free Space</td><td>0.3</td><td>4.3</td><td>1.0</td><td>0.3</td><td>3.7</td><td>0.3</td><td>5.0</td><td>0.7</td><td>3.2</td><td>1.5</td><td>1.7</td></tr>
+          <tr><td>View Angle</td><td>81.5</td><td>86.0</td><td>70.0</td><td>76.8</td><td>14.3</td><td>50.3</td><td>96.0</td><td>14.8</td><td>8.3</td><td>10.5</td><td>42.2</td></tr>
+          <tr><td>Repositioning</td><td>80.5</td><td>93.0</td><td>45.0</td><td>33.5</td><td>12.8</td><td>19.2</td><td>71.5</td><td>6.5</td><td>5.7</td><td>6.3</td><td>29.3</td></tr>
+          <tr><td>Max Box</td><td>1.5†</td><td>0.8†</td><td>1.0</td><td>3.0</td><td>2.0</td><td>2.8</td><td>6.5</td><td>0.8</td><td>1.5</td><td>1.0</td><td>2.3</td></tr>
+          <tr><td>Fit/Placement</td><td>90.7</td><td>91.2</td><td>71.5</td><td>80.0</td><td>83.7</td><td>87.7</td><td>91.8</td><td>75.0</td><td>75.5</td><td>72.8</td><td>72.7</td></tr>
+          <tr><td>Path (Valid)</td><td>10.0†</td><td>14.7†</td><td>33.0</td><td>26.7</td><td>30.5</td><td>26.7</td><td>53.2</td><td>7.3</td><td>21.7</td><td>16.7</td><td>33.5</td></tr>
+          <tr><td>Path (Fréchet)</td><td>13.2</td><td>14.2</td><td>23.7</td><td>17.8</td><td>19.2</td><td>14.7</td><td>48.0</td><td>2.5</td><td>14.2</td><td>6.8</td><td>25.2</td></tr>
+          <tr><td>Missing Object</td><td>73.0</td><td>76.2</td><td>51.0</td><td>49.3</td><td>29.5</td><td>36.0</td><td>65.5</td><td>9.7</td><td>28.3</td><td>11.7</td><td>32.3</td></tr>
+          <tr class="group-end"><td>Obstruction</td><td>80.7</td><td>96.5</td><td>24.3</td><td>7.3</td><td>3.8</td><td>9.3</td><td>84.7</td><td>2.5</td><td>5.2</td><td>4.7</td><td>11.7</td></tr>
+          <tr><td rowspan="11">B</td><td>Distance</td><td>98.7</td><td>99.8</td><td>99.5</td><td>98.2</td><td>96.3</td><td>98.8</td><td>99.8</td><td>87.0</td><td>81.8</td><td>58.8</td><td>98.5</td></tr>
+          <tr><td>Area (storage)</td><td>98.7</td><td>99.8</td><td>94.0</td><td>97.0</td><td>86.3</td><td>88.3</td><td>99.3</td><td>30.3</td><td>66.3</td><td>47.7</td><td>88.2</td></tr>
+          <tr><td>Free Space</td><td>1.7</td><td>5.8</td><td>1.2</td><td>0.3</td><td>2.5</td><td>1.2</td><td>2.8</td><td>1.8</td><td>1.0</td><td>1.0</td><td>1.2</td></tr>
+          <tr><td>View Angle</td><td>76.0</td><td>79.8</td><td>70.0</td><td>78.3</td><td>10.8</td><td>57.0</td><td>94.2</td><td>15.3</td><td>10.2</td><td>7.7</td><td>43.0</td></tr>
+          <tr><td>Repositioning</td><td>78.7</td><td>94.3</td><td>53.8</td><td>36.0</td><td>11.2</td><td>15.7</td><td>73.7</td><td>4.3</td><td>9.0</td><td>6.5</td><td>31.5</td></tr>
+          <tr><td>Max Box</td><td>0.7†</td><td>1.0†</td><td>2.0</td><td>1.8</td><td>2.0</td><td>2.5</td><td>7.2</td><td>1.0</td><td>0.7</td><td>1.0</td><td>2.0</td></tr>
+          <tr><td>Fit/Placement</td><td>86.3</td><td>86.3</td><td>65.8</td><td>66.7</td><td>66.5</td><td>73.0</td><td>82.0</td><td>66.0</td><td>63.8</td><td>64.7</td><td>66.2</td></tr>
+          <tr><td>Path (Valid)</td><td>15.5†</td><td>20.8†</td><td>49.7</td><td>40.7</td><td>38.5</td><td>35.8</td><td>67.8</td><td>11.3</td><td>34.5</td><td>20.5</td><td>48.8</td></tr>
+          <tr><td>Path (Fréchet)</td><td>15.3</td><td>21.5</td><td>30.3</td><td>30.3</td><td>27.0</td><td>19.0</td><td>49.5</td><td>3.7</td><td>19.7</td><td>8.5</td><td>36.3</td></tr>
+          <tr><td>Missing Object</td><td>64.3</td><td>65.2</td><td>39.8</td><td>40.3</td><td>33.0</td><td>25.2</td><td>61.0</td><td>14.8</td><td>19.7</td><td>8.3</td><td>34.5</td></tr>
+          <tr class="group-end"><td>Obstruction</td><td>87.2</td><td>95.7</td><td>32.0</td><td>4.3</td><td>1.3</td><td>5.8</td><td>89.5</td><td>2.2</td><td>5.3</td><td>9.3</td><td>12.2</td></tr>
+        </tbody>
+      </table>
+      <p class="table-note">†High truncation rate due to token limits.</p>
     </div>
   </section>
 

--- a/style.css
+++ b/style.css
@@ -88,6 +88,21 @@ table.benchmark td {
   text-align: center;
 }
 
+table.benchmark .group-end td {
+  border-bottom: 2px solid #666;
+}
+
+table.benchmark th:nth-child(1),
+table.benchmark td:nth-child(1),
+table.benchmark th:nth-child(2),
+table.benchmark td:nth-child(2),
+table.benchmark th:nth-child(4),
+table.benchmark td:nth-child(4),
+table.benchmark th:nth-child(9),
+table.benchmark td:nth-child(9) {
+  border-right: 2px solid #666;
+}
+
 table.benchmark th {
   background: #f0f0f0;
 }


### PR DESCRIPTION
## Summary
- reposition the benchmark results table to appear after the image gallery
- show room type only once for each block using rowspans
- add horizontal separators after each room type block
- add vertical separators between major column groups

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866536d4afc8321a618f43e6589265d