### PR TITLE
Update PlanQA page with logo, table, and gallery grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,9 @@
 
 <nav class="navbar" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
+    <a class="navbar-item" href="#">
+      <img src="./static/images/cropped_Logo.png" alt="PlanQA" style="max-height: 3rem;" />
+    </a>
     <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false">
       <span aria-hidden="true"></span>
       <span aria-hidden="true"></span>
@@ -57,25 +60,7 @@
       </span>
       </a>
 
-      <div class="navbar-item has-dropdown is-hoverable">
-        <a class="navbar-link">
-          More Research
-        </a>
-        <div class="navbar-dropdown">
-          <a class="navbar-item" href="https://hypernerf.github.io">
-            HyperNeRF
-          </a>
-          <a class="navbar-item" href="https://nerfies.github.io">
-            Nerfies
-          </a>
-          <a class="navbar-item" href="https://latentfusion.github.io">
-            LatentFusion
-          </a>
-          <a class="navbar-item" href="https://photoshape.github.io">
-            PhotoShape
-          </a>
-        </div>
-      </div>
+
     </div>
 
   </div>
@@ -87,6 +72,7 @@
     <div class="container is-max-desktop">
       <div class="columns is-centered">
         <div class="column has-text-centered">
+          <img src="./static/images/PlanQA_logo.png" alt="PlanQA Logo" style="max-height: 200px;" />
           <h1 class="title is-1 publication-title">PlanQA: A Benchmark for Spatial Reasoning in LLMs using Structured Representations</h1>
           <div class="is-size-5 publication-authors">
             <span class="author-block">Fedor Rodionov<sup>1</sup>,</span>
@@ -152,6 +138,111 @@
           </div>
         </div>
       </div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container-fluid table-container">
+    <h2 class="mb-3">Model Performance Analysis</h2>
+    <div class="table-responsive">
+      <table class="table table-bordered table-hover">
+        <caption>
+          <strong>Question-level accuracy by category for each model across room types.</strong>
+          <br>
+          <strong>Models (left to right):</strong> Qwen3-32B, DeepSeek-R1, DeepSeek-V3, LLaMA 3.3-70B, Gemma 2-27B, Phi-4, GPT-4.1, LLaMA 3.1-8B, Gemma 2-9B, Phi 3.5-mini, GPT-4o-mini.
+          <br>
+          <sup>†</sup><em>Note: High truncation rate due to token limits.</em>
+        </caption>
+        <thead class="table-light">
+          <tr>
+            <th colspan="2" scope="col" class="bold-v-divider"></th>
+            <th colspan="2" scope="col" class="cmidrule bold-v-divider">Reasoning</th>
+            <th colspan="5" scope="col" class="cmidrule bold-v-divider">Big Models</th>
+            <th colspan="4" scope="col" class="cmidrule">Small Models</th>
+          </tr>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col" class="bold-v-divider">N</th>
+            <th scope="col">32.8B</th>
+            <th scope="col" class="bold-v-divider">671B</th>
+            <th scope="col">671B</th><th scope="col">70B</th><th scope="col">27.2B</th><th scope="col">14B</th>
+            <th scope="col" class="bold-v-divider">N/A</th>
+            <th scope="col">8B</th><th scope="col">9.2B</th><th scope="col">3.8B</th><th scope="col">N/A</th>
+          </tr>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col" class="bold-v-divider">Temp.</th>
+            <th scope="col">0.6</th>
+            <th scope="col" class="bold-v-divider">0.6</th>
+            <th scope="col">0.3</th><th scope="col">0.0</th><th scope="col">0.5</th><th scope="col">0.0</th>
+            <th scope="col" class="bold-v-divider">1.0</th>
+            <th scope="col">0.6</th><th scope="col">0.5</th><th scope="col">0.7</th><th scope="col">1.0</th>
+          </tr>
+          <tr class="logo-row">
+            <th scope="col">Type</th>
+            <th scope="col" class="bold-v-divider">Category</th>
+            <th scope="col"><img src="logos/qwen-color.png" alt="Qwen Logo" class="model-logo"></th>
+            <th scope="col" class="bold-v-divider"><img src="logos/deepseek-color.png" alt="DeepSeek Logo" class="model-logo"></th>
+            <th scope="col"><img src="logos/deepseek-color.png" alt="DeepSeek Logo" class="model-logo"></th>
+            <th scope="col"><img src="logos/meta-color.png" alt="Meta Logo" class="model-logo"></th>
+            <th scope="col"><img src="logos/gemma%20(1).png" alt="Gemma Logo" class="model-logo"></th>
+            <th scope="col"><img src="logos/microsoft-color.png" alt="Microsoft Logo" class="model-logo"></th>
+            <th scope="col" class="bold-v-divider"><img src="logos/openai%20(1).png" alt="OpenAI Logo" class="model-logo"></th>
+            <th scope="col"><img src="logos/meta-color.png" alt="Meta Logo" class="model-logo"></th>
+            <th scope="col"><img src="logos/gemma%20(1).png" alt="Gemma Logo" class="model-logo"></th>
+            <th scope="col"><img src="logos/microsoft-color.png" alt="Microsoft Logo" class="model-logo"></th>
+            <th scope="col"><img src="logos/openai%20(1).png" alt="OpenAI Logo" class="model-logo"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td rowspan="11" class="category-group-header bold-v-divider">K</td>
+            <th scope="row" class="bold-v-divider">Distance</th>
+            <td>97.2</td><td class="highlight-15 bold-v-divider">99.5</td><td>98.5</td><td>97.2</td><td>94.7</td><td>90.7</td><td class="highlight-30 bold-v-divider">100</td><td>82.3</td><td>74.2</td><td>35.3</td><td>97.3</td>
+          </tr>
+          <tr><th scope="row" class="bold-v-divider">Area (counters)</th><td>85.3</td><td class="highlight-30 bold-v-divider">99.5</td><td>95.7</td><td>81.7</td><td>46.5</td><td>79.2</td><td class="highlight-15 bold-v-divider">98.5</td><td>30.8</td><td>37.5</td><td>9.8</td><td>80.3</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Free Space</th><td class="highlight-15">83.7</td><td class="highlight-30 bold-v-divider">88.0</td><td>52.5</td><td>37.0</td><td>23.5</td><td>42.0</td><td class="bold-v-divider">83.5</td><td>9.5</td><td>13.5</td><td>6.3</td><td>20.3</td></tr>
+          <tr><th scope="row" class="bold-v-divider">View Angle</th><td>74.0</td><td class="bold-v-divider">58.2</td><td>69.2</td><td class="highlight-15">75.2</td><td>12.7</td><td>52.8</td><td class="highlight-30 bold-v-divider">86.3</td><td>11.5</td><td>9.2</td><td>8.2</td><td>42.2</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Repositioning</th><td class="highlight-15">91.5</td><td class="highlight-30 bold-v-divider">96.3</td><td>69.8</td><td>48.7</td><td>14.8</td><td>22.7</td><td class="bold-v-divider">85.8</td><td>3.7</td><td>6.2</td><td>11.5</td><td>40.7</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Max Box</th><td class="highlight-15">33.3</td><td class="bold-v-divider">30.7</td><td>9.2</td><td>8.8</td><td>3.0</td><td>3.0</td><td class="highlight-30 bold-v-divider">57.2</td><td>1.7</td><td>1.2</td><td>1.7</td><td>3.7</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Fit/Placement</th><td class="highlight-30">92.8</td><td class="highlight-15 bold-v-divider">92.5</td><td>71.0</td><td>66.2</td><td>72.0</td><td>82.0</td><td class="bold-v-divider">89.8</td><td>68.7</td><td>71.8</td><td>68.8</td><td>70.7</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Path (Valid)</th><td>13.2<sup>†</sup></td><td class="bold-v-divider">6.3<sup>†</sup></td><td class="highlight-15">39.3</td><td>30.3</td><td>23.2</td><td>26.8</td><td class="highlight-30 bold-v-divider">73.0</td><td>10.5</td><td>17.5</td><td>14.8</td><td>35.7</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Path (Fréchet)</th><td>15.0</td><td class="bold-v-divider">6.3</td><td>32.8</td><td>30.2</td><td>26.0</td><td>26.0</td><td class="highlight-30 bold-v-divider">55.8</td><td>10.2</td><td>19.0</td><td>9.3</td><td class="highlight-15">36.7</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Missing Object</th><td class="highlight-15">87.3</td><td class="highlight-30 bold-v-divider">88.7</td><td>44.3</td><td>56.2</td><td>52.3</td><td>52.2</td><td class="bold-v-divider">79.8</td><td>27.5</td><td>39.7</td><td>14.3</td><td>58.0</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Obstruction</th><td>84.0</td><td class="highlight-30 bold-v-divider">95.2</td><td>32.7</td><td>6.0</td><td>3.3</td><td>9.7</td><td class="highlight-15 bold-v-divider">93.5</td><td>1.2</td><td>2.7</td><td>11.3</td><td>14.2</td></tr>
+          <tr class="block-start">
+            <td rowspan="11" class="category-group-header bold-v-divider">L</td>
+            <th scope="row" class="bold-v-divider">Distance</th>
+            <td>98.7</td><td class="highlight-15 bold-v-divider">99.8</td><td>99.5</td><td>98.2</td><td>96.3</td><td>98.8</td><td class="highlight-30 bold-v-divider">99.8</td><td>87.0</td><td>81.8</td><td>58.8</td><td>98.5</td>
+          </tr>
+          <tr><th scope="row" class="bold-v-divider">Area (sitting)</th><td>96.7</td><td class="highlight-15 bold-v-divider">99.5</td><td>84.5</td><td>98.0</td><td>83.8</td><td>88.7</td><td class="highlight-30 bold-v-divider">99.5</td><td>32.5</td><td>41.3</td><td>12.8</td><td>85.7</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Free Space</th><td>0.3</td><td class="highlight-15 bold-v-divider">4.3</td><td>1.0</td><td>0.3</td><td>3.7</td><td>0.3</td><td class="highlight-30 bold-v-divider">5.0</td><td>0.7</td><td>3.2</td><td>1.5</td><td>1.7</td></tr>
+          <tr><th scope="row" class="bold-v-divider">View Angle</th><td>81.5</td><td class="highlight-15 bold-v-divider">86.0</td><td>70.0</td><td>76.8</td><td>14.3</td><td>50.3</td><td class="highlight-30 bold-v-divider">96.0</td><td>14.8</td><td>8.3</td><td>10.5</td><td>42.2</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Repositioning</th><td class="highlight-15">80.5</td><td class="highlight-30 bold-v-divider">93.0</td><td>45.0</td><td>33.5</td><td>12.8</td><td>19.2</td><td class="bold-v-divider">71.5</td><td>6.5</td><td>5.7</td><td>6.3</td><td>29.3</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Max Box</th><td>1.5<sup>†</sup></td><td class="bold-v-divider">0.8<sup>†</sup></td><td>1.0</td><td class="highlight-15">3.0</td><td>2.0</td><td>2.8</td><td class="highlight-30 bold-v-divider">6.5</td><td>0.8</td><td>1.5</td><td>1.0</td><td>2.3</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Fit/Placement</th><td>90.7</td><td class="highlight-15 bold-v-divider">91.2</td><td>71.5</td><td>80.0</td><td>83.7</td><td>87.7</td><td class="highlight-30 bold-v-divider">91.8</td><td>75.0</td><td>75.5</td><td>72.8</td><td>72.7</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Path (Valid)</th><td>10.0<sup>†</sup></td><td class="bold-v-divider">14.7<sup>†</sup></td><td>33.0</td><td>26.7</td><td>30.5</td><td>26.7</td><td class="highlight-30 bold-v-divider">53.2</td><td>7.3</td><td>21.7</td><td>16.7</td><td class="highlight-15">33.5</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Path (Fréchet)</th><td>13.2</td><td class="bold-v-divider">14.2</td><td>23.7</td><td>17.8</td><td>19.2</td><td>14.7</td><td class="highlight-30 bold-v-divider">48.0</td><td>2.5</td><td>14.2</td><td>6.8</td><td class="highlight-15">25.2</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Missing Object</th><td class="highlight-15">73.0</td><td class="highlight-30 bold-v-divider">76.2</td><td>51.0</td><td>49.3</td><td>29.5</td><td>36.0</td><td class="bold-v-divider">65.5</td><td>9.7</td><td>28.3</td><td>11.7</td><td>32.3</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Obstruction</th><td>80.7</td><td class="highlight-30 bold-v-divider">96.5</td><td>24.3</td><td>7.3</td><td>3.8</td><td>9.3</td><td class="highlight-15 bold-v-divider">84.7</td><td>2.5</td><td>5.2</td><td>4.7</td><td>11.7</td></tr>
+          <tr class="block-start">
+            <td rowspan="11" class="category-group-header bold-v-divider">B</td>
+            <th scope="row" class="bold-v-divider">Distance</th>
+            <td>98.7</td><td class="highlight-15 bold-v-divider">99.8</td><td>99.5</td><td>98.2</td><td>96.3</td><td>98.8</td><td class="highlight-30 bold-v-divider">99.8</td><td>87.0</td><td>81.8</td><td>58.8</td><td>98.5</td>
+          </tr>
+          <tr><th scope="row" class="bold-v-divider">Area (storage)</th><td>98.7</td><td class="highlight-30 bold-v-divider">99.8</td><td>94.0</td><td>97.0</td><td>86.3</td><td>88.3</td><td class="highlight-15 bold-v-divider">99.3</td><td>30.3</td><td>66.3</td><td>47.7</td><td>88.2</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Free Space</th><td>1.7</td><td class="highlight-30 bold-v-divider">5.8</td><td>1.2</td><td>0.3</td><td>2.5</td><td>1.2</td><td class="highlight-15 bold-v-divider">2.8</td><td>1.8</td><td>1.0</td><td>1.0</td><td>1.2</td></tr>
+          <tr><th scope="row" class="bold-v-divider">View Angle</th><td>76.0</td><td class="highlight-15 bold-v-divider">79.8</td><td>70.0</td><td>78.3</td><td>10.8</td><td>57.0</td><td class="highlight-30 bold-v-divider">94.2</td><td>15.3</td><td>10.2</td><td>7.7</td><td>43.0</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Repositioning</th><td class="highlight-15">78.7</td><td class="highlight-30 bold-v-divider">94.3</td><td>53.8</td><td>36.0</td><td>11.2</td><td>15.7</td><td class="bold-v-divider">73.7</td><td>4.3</td><td>9.0</td><td>6.5</td><td>31.5</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Max Box</th><td>0.7<sup>†</sup></td><td class="bold-v-divider">1.0<sup>†</sup></td><td>2.0</td><td>1.8</td><td>2.0</td><td class="highlight-15">2.5</td><td class="highlight-30 bold-v-divider">7.2</td><td>1.0</td><td>0.7</td><td>1.0</td><td>2.0</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Fit/Placement</th><td class="highlight-15">86.3</td><td class="highlight-30 bold-v-divider">86.3</td><td>65.8</td><td>66.7</td><td>66.5</td><td>73.0</td><td class="bold-v-divider">82.0</td><td>66.0</td><td>63.8</td><td>64.7</td><td>66.2</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Path (Valid)</th><td>15.5<sup>†</sup></td><td class="bold-v-divider">20.8<sup>†</sup></td><td class="highlight-15">49.7</td><td>40.7</td><td>38.5</td><td>35.8</td><td class="highlight-30 bold-v-divider">67.8</td><td>11.3</td><td>34.5</td><td>20.5</td><td>48.8</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Path (Fréchet)</th><td>15.3</td><td class="bold-v-divider">21.5</td><td>30.3</td><td>30.3</td><td>27.0</td><td>19.0</td><td class="highlight-30 bold-v-divider">49.5</td><td>3.7</td><td>19.7</td><td>8.5</td><td class="highlight-15">36.3</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Missing Object</th><td class="highlight-15">64.3</td><td class="highlight-30 bold-v-divider">65.2</td><td>39.8</td><td>40.3</td><td>33.0</td><td>25.2</td><td class="bold-v-divider">61.0</td><td>14.8</td><td>19.7</td><td>8.3</td><td>34.5</td></tr>
+          <tr><th scope="row" class="bold-v-divider">Obstruction</th><td>87.2</td><td class="highlight-30 bold-v-divider">95.7</td><td>32.0</td><td>4.3</td><td>1.3</td><td>5.8</td><td class="highlight-15 bold-v-divider">89.5</td><td>2.2</td><td>5.3</td><td>9.3</td><td>12.2</td></tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </section>

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -157,7 +157,7 @@ body {
 }
 #gallery .gallery {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   grid-gap: 10px;
 }
 


### PR DESCRIPTION
## Summary
- add site logo in navbar using `cropped_Logo.png`
- include `PlanQA_logo.png` at the beginning of the hero section
- remove "More Research" dropdown from navigation
- show model performance table
- force example layout gallery to display a 3x3 grid

## Testing
- `tidy -v` *(fails: tidy not installed)*
- `html5validator --version` *(fails: validator not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867ce12a7f48321983ecaa39e84a458