### PR TITLE
Add arXiv links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This repository contains the source code for the PlanQA project website.
 
+The PlanQA paper is available on [arXiv](https://arxiv.org/abs/2507.07644v1)
+([PDF](https://arxiv.org/pdf/2507.07644v1)).
+
 If you find PlanQA useful for your work please cite:
 ```
 @article{rodionov2025planqa,

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
             <div class="publication-links">
               <!-- PDF Link. -->
               <span class="link-block">
-                <a href="#"
+                <a href="https://arxiv.org/pdf/2507.07644v1"
                    class="external-link button is-normal is-rounded is-dark">
                   <span class="icon">
                       <i class="fas fa-file-pdf"></i>
@@ -150,7 +150,7 @@
                 </a>
               </span>
               <span class="link-block">
-                <a href="#"
+                <a href="https://arxiv.org/abs/2507.07644v1"
                    class="external-link button is-normal is-rounded is-dark">
                   <span class="icon">
                       <i class="ai ai-arxiv"></i>
@@ -337,7 +337,7 @@
   <div class="container">
     <div class="content has-text-centered">
       <a class="icon-link"
-         href="#">
+         href="https://arxiv.org/pdf/2507.07644v1">
         <i class="fas fa-file-pdf"></i>
       </a>
       <a class="icon-link" href="#" class="external-link" disabled>


### PR DESCRIPTION
## Summary
- include link to the PlanQA paper on arXiv in the README
- set Paper and arXiv buttons to the proper link in the website
- update footer PDF icon with the arXiv PDF link

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878c28063948321997eedf61c7e8355